### PR TITLE
54 input not added to filenames in benchmark results

### DIFF
--- a/benchRunners/bench_func.sh
+++ b/benchRunners/bench_func.sh
@@ -7,7 +7,14 @@ runbenchmark(){
     echo --- Starting $language ---
     $cmd $input
     sleep 5s
-    bash utils/append_to_latest_csv.sh "$language$testName$inputSize"
+
+    #adding input or inputSize, depending on whether inputSize is present.
+    if [ -n "$inputSize" ]; then
+        bash utils/append_to_latest_csv.sh "${language}_${testName}_${inputSize}"
+    else
+        bash utils/append_to_latest_csv.sh "${language}_${testName}_${input}"
+    fi
+
     echo --- $language Done ---
     echo
 }

--- a/benchRunners/quicksort.sh
+++ b/benchRunners/quicksort.sh
@@ -1,42 +1,43 @@
+source ./benchRunners/count_input_params.sh
 source ./benchRunners/bench_func.sh
 
 testName="quicksort"
 folder="quicksort"
 count=1000
 input=`cat benchRunners/mergeSortParam` # getting input from file
-
+inputLength=$(count_params $input)
 
 echo "!!! Starting $testName !!!"
 echo
 
 #   Node
 cmd="node ./benchmarks/$folder/javascript/bench.js $count"
-runbenchmark "Node" $testName "$cmd" "$input"
+runbenchmark "Node" $testName "$cmd" "$input" $inputLength
 
 #   Python
 cmd="python3 ./benchmarks/$folder/python/bench.py $count"
-runbenchmark "Python" $testName "$cmd" "$input"
+runbenchmark "Python" $testName "$cmd" "$input" $inputLength
 
 #   Pypy
 cmd="pypy ./benchmarks/$folder/python/bench.py $count"
-runbenchmark "Pypy" $testName "$cmd" "$input"
+runbenchmark "Pypy" $testName "$cmd" "$input" $inputLength
 
 #   C#
 cmd="dotnet run --project ./benchmarks/$folder/csharp/bench.csproj --configuration Release $count"
-runbenchmark "Csharp" $testName "$cmd" "$input"
+runbenchmark "Csharp" $testName "$cmd" "$input" $inputLength
 
 #   Java
 cmd="java --enable-native-access=ALL-UNNAMED --enable-preview --source 21 ./benchmarks/$folder/java/Bench.java $count"
-runbenchmark "Java" $testName "$cmd" "$input"
+runbenchmark "Java" $testName "$cmd" "$input" $inputLength
 
 #   C
 gcc benchmarks/$folder/c/bench.c -O3 -o benchmarks/$folder/c/bench -L./target/release -lrapl_lib -Wl,-rpath=./target/release
 cmd="./benchmarks/$folder/c/bench $count"
-runbenchmark "C" $testName "$cmd" "$input"
+runbenchmark "C" $testName "$cmd" "$input" $inputLength
 
 #   C++
 g++ benchmarks/$folder/cpp/bench.cpp -O3 -o benchmarks/$folder/cpp/bench -L./target/release -lrapl_lib -Wl,-rpath=./target/release 
 cmd="./benchmarks/$folder/cpp/bench $count"
-runbenchmark "Cpp" $testName "$cmd" "$input"
+runbenchmark "Cpp" $testName "$cmd" "$input" $inputLength
 
 echo "!!! Finished $testName !!!"


### PR DESCRIPTION
The last attempt failed somehow, fixed it with an if statement
+ quicksort was missing an inputLength variable 